### PR TITLE
chore: configure nodus technical mono design system

### DIFF
--- a/nodus-frontend/index.html
+++ b/nodus-frontend/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500&family=Space+Grotesk:wght@700&display=swap" rel="stylesheet">
     <title>nodus-frontend</title>
   </head>
   <body>

--- a/nodus-frontend/tailwind.config.js
+++ b/nodus-frontend/tailwind.config.js
@@ -1,11 +1,43 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-  content: [
-    "./index.html",
-    "./src/**/*.{js,ts,jsx,tsx}",
-  ],
+  content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        // Primary Accent
+        indigo: {
+          electric: "#4F46E5",
+        },
+        // Backgrounds
+        surface: {
+          white: "#FFFFFF",
+          gray: "#F9FAFB",
+        },
+        // Typography
+        content: {
+          charcoal: "#111827",
+          slate: "#4B5563",
+        },
+        // Borders
+        outline: {
+          subtle: "#E5E7EB",
+        },
+      },
+      fontFamily: {
+        // Inter is set as the default sans-serif for body text
+        sans: ["Inter", "sans-serif"],
+        // Space Grotesk specifically for technical headings
+        display: ['"Space Grotesk"', "sans-serif"],
+      },
+      borderRadius: {
+        // 8px corner radius
+        nodus: "8px",
+      },
+      boxShadow: {
+        // Flat, subtle shadow favoring the 1px border aesthetic
+        flat: "0 1px 2px 0 rgba(0, 0, 0, 0.05)",
+      },
+    },
   },
   plugins: [],
-}
+};


### PR DESCRIPTION
Set up the initial Tailwind design system by defining reusable design tokens for colors, typography, spacing, and shadows based on the Nodus technical mono UI style.

Changes
- Extended Tailwind theme with custom color palette:
- Primary (indigo.electric)
- Backgrounds (surface.white, surface.gray)
- Typography colors (content.charcoal, content.slate)
- Border color (outline.subtle)
 
Configured custom fonts:
- Inter for body text
- Space Grotesk for headings
- Added custom border radius (rounded-nodus)
- Added subtle shadow style (shadow-flat)
- Integrated Google Fonts in index.html for font loading
- Updated Tailwind content paths for proper class scanning